### PR TITLE
Issue #2 - ^C to stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ The name fortio comes from greek φορτίο which is load/burden.
 2. `go get -u istio.io/fortio`
 3. you can now run `fortio` (from your gopath bin/ directory)
 
-Or
+Or use docker, for instance:
 
-`docker run istio/fortio arguments...`
-
+```shell
+docker run -p 8080:8080 -p 8079:8079 istio/fortio server &
+docker run istio/fortio load http://$HOSTNAME:8080/
+```
 
 ## Command line arguments
 
-Fortio can be and http or grpc load generator, gathering statistics using the `load` command, or start simple http and grpc ping servers with the `server` command or issue grpc ping messages using the `grpcping` command.
+Fortio can be an http or grpc load generator, gathering statistics using the `load` command, or start simple http and grpc ping servers with the `server` command or issue grpc ping messages using the `grpcping` command.
 
 ```
 $ fortio
@@ -79,13 +81,13 @@ and flags are:
 
 ## Example use and output
 
-Start the internal servers:
+* Start the internal servers:
 ```
 $ fortio server &
 Fortio 0.2.2 echo server listening on port 8080
 Fortio 0.2.2 grpc ping server listening on port 8079
 ```
-Simple grpc ping:
+* Simple grpc ping:
 ```
 $ fortio grpcping localhost
 02:29:27 I pingsrv.go:116> Ping RTT 305334 (avg of 342970, 293515, 279517 ns) clock skew -2137
@@ -99,7 +101,7 @@ RTT histogram usec : count 3 avg 305.334 +/- 27.22 min 279.517 max 342.97 sum 91
 >= 300 < 350 , 325 , 100.00, 1
 # target 50% 294.879
 ```
-Load (low default qps/threading) test:
+* Load (low default qps/threading) test:
 ```
 $ fortio load http://www.google.com
 Fortio running at 8 queries per second, 8->8 procs, for 5s: http://www.google.com

--- a/periodic/periodic.go
+++ b/periodic/periodic.go
@@ -118,7 +118,7 @@ func newPeriodicRunner(opts *RunnerOptions) *periodicRunner {
 	if r.Resolution <= 0 {
 		r.Resolution = DefaultRunnerOptions.Resolution
 	}
-	if r.Duration <= 0 {
+	if r.Duration < 0 {
 		r.Duration = DefaultRunnerOptions.Duration
 	}
 	return r
@@ -137,25 +137,38 @@ func (r *periodicRunner) Options() *RunnerOptions {
 // Run starts the runner.
 func (r *periodicRunner) Run() RunnerResults {
 	useQPS := (r.QPS > 0)
+	hasDuration := (r.Duration > 0)
 	var numCalls int64
 	if useQPS {
-		numCalls = int64(r.QPS * r.Duration.Seconds())
-		if numCalls < 2 {
-			log.Warnf("Increasing the number of calls to the minimum of 2 with 1 thread. total duration will increase")
-			numCalls = 2
-			r.NumThreads = 1
+		// r.Duration will be 0 if endless flag has been provided. Otherwise it will have the provided duration time.
+		if hasDuration {
+			numCalls = int64(r.QPS * r.Duration.Seconds())
+			if numCalls < 2 {
+				log.Warnf("Increasing the number of calls to the minimum of 2 with 1 thread. total duration will increase")
+				numCalls = 2
+				r.NumThreads = 1
+			}
+			if int64(2*r.NumThreads) > numCalls {
+				r.NumThreads = int(numCalls / 2)
+				log.Warnf("Lowering number of threads - total call %d -> lowering to %d threads", numCalls, r.NumThreads)
+			}
+			numCalls /= int64(r.NumThreads)
+			totalCalls := numCalls * int64(r.NumThreads)
+			fmt.Printf("Starting at %g qps with %d thread(s) [gomax %d] for %v : %d calls each (total %d)\n",
+				r.QPS, r.NumThreads, runtime.GOMAXPROCS(0), r.Duration, numCalls, totalCalls)
+		} else {
+			fmt.Printf("Starting at %g qps with %d thread(s) [gomax %d] until interrupted\n",
+				r.QPS, r.NumThreads, runtime.GOMAXPROCS(0))
+			numCalls = 0
 		}
-		if int64(2*r.NumThreads) > numCalls {
-			r.NumThreads = int(numCalls / 2)
-			log.Warnf("Lowering number of threads - total call %d -> lowering to %d threads", numCalls, r.NumThreads)
-		}
-		numCalls /= int64(r.NumThreads)
-		totalCalls := numCalls * int64(r.NumThreads)
-		fmt.Printf("Starting at %g qps with %d thread(s) [gomax %d] for %v : %d calls each (total %d)\n",
-			r.QPS, r.NumThreads, runtime.GOMAXPROCS(0), r.Duration, numCalls, totalCalls)
 	} else {
-		fmt.Printf("Starting at max qps with %d thread(s) [gomax %d] for %v\n",
-			r.NumThreads, runtime.GOMAXPROCS(0), r.Duration)
+		fmt.Printf("Starting at max qps with %d thread(s) [gomax %d] ",
+			r.NumThreads, runtime.GOMAXPROCS(0))
+		if hasDuration {
+			fmt.Printf("for %v\n", r.Duration)
+		} else {
+			fmt.Printf("until interrupted\n")
+		}
 	}
 	start := time.Now()
 	// Histogram  and stats for Function duration - millisecond precision
@@ -237,7 +250,7 @@ func runOne(id int, funcTimes *stats.Histogram, sleepTimes *stats.Histogram, num
 		}
 
 		fStart := time.Now()
-		if fStart.After(endTime) {
+		if r.Duration > 0 && fStart.After(endTime) {
 			if !useQPS {
 				// max speed test reached end:
 				break
@@ -254,13 +267,19 @@ func runOne(id int, funcTimes *stats.Histogram, sleepTimes *stats.Histogram, num
 		i++
 		// if using QPS / pre calc expected call # mode:
 		if useQPS {
-			if i >= numCalls {
+			if numCalls > 0 && i >= numCalls {
 				break // expected exit for that mode
 			}
 			elapsed := time.Since(start)
-			// This next line is tricky - such as for 2s duration and 1qps there is 1
-			// sleep of 2s between the 2 calls and for 3qps in 1sec 2 sleep of 1/2s etc
-			targetElapsedInSec := (float64(i) + float64(i)/float64(numCalls-1)) / perThreadQPS
+			var targetElapsedInSec float64
+			if numCalls > 0 {
+				// This next line is tricky - such as for 2s duration and 1qps there is 1
+				// sleep of 2s between the 2 calls and for 3qps in 1sec 2 sleep of 1/2s etc
+				targetElapsedInSec = (float64(i) + float64(i)/float64(numCalls-1)) / perThreadQPS
+			} else {
+				// Calculate the target elapsed when in endless execution
+				targetElapsedInSec = float64(i) / perThreadQPS
+			}
 			targetElapsedDuration := time.Duration(int64(targetElapsedInSec * 1e9))
 			sleepDuration := targetElapsedDuration - elapsed
 			log.Debugf("%s target next dur %v - sleep %v", tIDStr, targetElapsedDuration, sleepDuration)


### PR DESCRIPTION
This PR adds the following new features (as suggested in Issue #2):
- Support stopping running load with ^C
- New `-endless` flag will run the load without duration time (until ^C)

In both interrupts the info collected until interrupt will be printed.